### PR TITLE
Version bump 1.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         vectorDrawables.useSupportLibrary = true
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 2
+        versionName "1.0.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         buildConfigField "String" , "API_KEY" ,  "\"$THE_MOVIE_DATABASE_API_KEY\""
     }

--- a/app/src/main/java/com/database/movie/data_layer/database/DBHelper.java
+++ b/app/src/main/java/com/database/movie/data_layer/database/DBHelper.java
@@ -34,7 +34,7 @@ import javax.inject.Singleton;
 public class DBHelper extends SQLiteOpenHelper {
 
     private static final String DB_NAME = "the_movie_database.db";
-    private static final int DB_VERSION = 1;
+    private static final int DB_VERSION = 2;
     private static final String TAG = DBHelper.class.getSimpleName();
 
     public DBHelper(Context context){

--- a/app/src/main/java/com/database/movie/data_layer/database/entity/IMovie.java
+++ b/app/src/main/java/com/database/movie/data_layer/database/entity/IMovie.java
@@ -49,7 +49,7 @@ public interface IMovie extends IBaseTable {
             + Columns.VOTE_AVERAGE + " REAL, "
             + Columns.BACKDROP_PATH + " TEXT, "
             + Columns.ADULT + " TEXT, "
-            + Columns.ID + " INTEGER, "
+            + Columns.ID + " REAL, "
             + Columns.TITLE + " TEXT, "
             + Columns.OVERVIEW + " TEXT, "
             + Columns.ORIGINAL_LANGUAGE + " TEXT, "

--- a/app/src/main/java/com/database/movie/data_layer/database/entity/IMovieID.java
+++ b/app/src/main/java/com/database/movie/data_layer/database/entity/IMovieID.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Ilanthirayan Paramanathan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.database.movie.data_layer.database.entity;
+
+import android.provider.BaseColumns;
+
+/**
+ * @author Ilanthirayan Paramanathan <theebankala@gmail.com>
+ * @version 1.0.0
+ * @since 15th of January 2018
+ */
+public interface IMovieID extends IBaseTable {
+
+    interface Columns extends BaseColumns {
+        String ID = "id";
+    }
+}

--- a/app/src/main/java/com/database/movie/data_layer/database/entity/INowPlayingMovie.java
+++ b/app/src/main/java/com/database/movie/data_layer/database/entity/INowPlayingMovie.java
@@ -15,25 +15,19 @@
  */
 package com.database.movie.data_layer.database.entity;
 
-import android.provider.BaseColumns;
-
 /**
  * @author Ilanthirayan Paramanathan <theebankala@gmail.com>
  * @version 1.0.0
- * @since 15th of January 2018
+ * @since 16th of January 2018
  */
-public interface INowPlayingMovie extends IBaseTable {
-
-    interface Columns extends BaseColumns {
-        String ID = "id";
-    }
+public interface INowPlayingMovie extends IMovieID {
 
     String TABLE_NAME = "tbl_now_playing_movie";
 
     String CREATE_TABLE_NOW_PLAYING_MOVIES = CREATE_TABLE
             + TABLE_NAME + " ("
             + Columns._ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
-            + Columns.ID+ " INTEGER); ";
+            + Columns.ID+ " REAL); ";
 
     String CREATE_NOW_PLAYING_MOVIES_INDEX_ID = CREATE_INDEX
             + CREATE_INDEX_BASED_ON

--- a/app/src/main/java/com/database/movie/data_layer/model/Movie.java
+++ b/app/src/main/java/com/database/movie/data_layer/model/Movie.java
@@ -191,7 +191,7 @@ public class Movie {
         setVote_count(cursor.getInt(i));
 
         i = cursor.getColumnIndexOrThrow(IMovie.Columns.ID);
-        setId(cursor.getInt(i));
+        setId(cursor.getLong(i));
 
         i = cursor.getColumnIndexOrThrow(IMovie.Columns.VIDEO);
         setVideo(Boolean.valueOf(cursor.getString(i)));

--- a/app/src/main/java/com/database/movie/data_layer/model/MovieID.java
+++ b/app/src/main/java/com/database/movie/data_layer/model/MovieID.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 Ilanthirayan Paramanathan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.database.movie.data_layer.model;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import com.database.movie.data_layer.database.entity.IMovieID;
+
+/**
+ * @author Ilanthirayan Paramanathan <theebankala@gmail.com>
+ * @version 1.0.0
+ * @since 16th of January 2018
+ */
+public class MovieID {
+
+    private long id;
+
+    public MovieID(long id) {
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public MovieID(Cursor cursor) {
+        fromCursor(cursor);
+    }
+
+    private void fromCursor(Cursor cursor) {
+        int i = cursor.getColumnIndexOrThrow(IMovieID.Columns.ID);
+        setId(cursor.getLong(i));
+    }
+
+    public ContentValues toContentValues() {
+        final ContentValues values = new ContentValues();
+        values.put(IMovieID.Columns.ID, getId());
+        return values;
+    }
+}

--- a/app/src/main/java/com/database/movie/data_layer/source/now_playing/disk/DiskNowPlayingMoviesDataSource.java
+++ b/app/src/main/java/com/database/movie/data_layer/source/now_playing/disk/DiskNowPlayingMoviesDataSource.java
@@ -15,6 +15,8 @@
  */
 package com.database.movie.data_layer.source.now_playing.disk;
 
+import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
@@ -22,10 +24,15 @@ import android.util.Log;
 import com.database.movie.data_layer.api.response.PaginatedMovies;
 import com.database.movie.data_layer.database.DataBaseManager;
 import com.database.movie.data_layer.database.entity.IMovie;
+import com.database.movie.data_layer.database.entity.IMovieID;
 import com.database.movie.data_layer.database.entity.INowPlayingMovie;
 import com.database.movie.data_layer.model.Movie;
+import com.database.movie.data_layer.model.MovieID;
 import com.database.movie.data_layer.source.now_playing.NowPlayingMoviesDataSource;
 import com.google.gson.Gson;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import io.reactivex.Observable;
 
@@ -50,7 +57,7 @@ public class DiskNowPlayingMoviesDataSource implements NowPlayingMoviesDataSourc
     }
 
     /**
-     * Get {@link PaginatedMovies} from SQLite {@link INowPlayingMovie} table (Local)
+     * Get {@link PaginatedMovies} from SQLite {@link IMovieID} table (Local)
      *
      * @param current_page
      * @param per_page
@@ -58,18 +65,75 @@ public class DiskNowPlayingMoviesDataSource implements NowPlayingMoviesDataSourc
      */
     @Override
     public Observable getNowPlayingMovies(int current_page, int per_page) {
-        return Observable.just(new PaginatedMovies());
+        SQLiteDatabase db = mDataBaseManager.openReadableDatabase();
+        List<MovieID> nowPlayingMovieIDList = new ArrayList<>();
+        List<Movie> nowPlayingMovieList = new ArrayList<>();
+        try {
+            String sql = "SELECT * FROM " + INowPlayingMovie.TABLE_NAME + " LIMIT " + per_page + " OFFSET " + current_page * per_page;
+            Cursor cursor = db.rawQuery(sql, null);
+            if (cursor.getCount() != 0) {
+                while (cursor.moveToNext()) {
+                    nowPlayingMovieIDList.add(new MovieID(cursor));
+                }
+            }
+            cursor.close();
+
+            final String selections = IMovie.Columns.ID + " = ? ";
+            for (MovieID movieID : nowPlayingMovieIDList) {
+                final String[] selectionArgs = {String.valueOf(movieID.getId())};
+                Cursor cursorMovie = db.query(IMovie.TABLE_NAME, null, selections, selectionArgs, null, null, null);
+                //check is if Movie exist
+                if(cursorMovie.moveToFirst()){
+                    nowPlayingMovieList.add(new Movie(cursorMovie, mGson));
+                }
+                cursorMovie.close();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            mDataBaseManager.closeReadableSQLiteDatabase();
+        }
+        PaginatedMovies paginatedMovies = new PaginatedMovies();
+        paginatedMovies.setPage(current_page);
+        int total_movies = countNowPlayingMoviesLocally();
+        paginatedMovies.setTotal_results(total_movies);
+        int reminder = total_movies % per_page;
+        int total_pages = total_movies / per_page;
+        if(reminder > 0){
+            paginatedMovies.setTotal_pages(total_pages + 1);
+        }else{
+            paginatedMovies.setTotal_pages(total_pages);
+        }
+        paginatedMovies.setResults(nowPlayingMovieList.toArray(new Movie[nowPlayingMovieList.size()]));
+        return Observable.just(paginatedMovies);
+    }
+
+    private int countNowPlayingMoviesLocally() {
+        int count = 0;
+        SQLiteDatabase db = mDataBaseManager.openReadableDatabase();
+        try {
+            count = (int) DatabaseUtils.queryNumEntries(db, INowPlayingMovie.TABLE_NAME, null, null);
+        }catch(SQLException e){
+            e.printStackTrace();
+        }finally {
+            mDataBaseManager.closeReadableSQLiteDatabase();
+        }
+        return count;
     }
 
     @Override
     public Observable saveNowPlayingMovies(PaginatedMovies paginatedMovies) {
         final SQLiteDatabase db = mDataBaseManager.openWritableDatabase();
         final String whereClause = IMovie.Columns.ID + " = ?  ";
+        final String whereClauseNowPlaying = INowPlayingMovie.Columns.ID + " = ?  ";
         try {
             db.beginTransaction();
+            if(paginatedMovies.getPage() == 1){//can't ascending or descending order by ID because ID not in order
+                //clear the table and then insert
+                db.delete(INowPlayingMovie.TABLE_NAME, null, null);
+            }
             for (Movie movie : paginatedMovies.getResults()) {
                 final String[] whereArgs = {String.valueOf(movie.getId())};
-
                 boolean isUpdated = db.update(IMovie.TABLE_NAME, movie.toContentValues(mGson), whereClause, whereArgs) > 0;
                 if (isUpdated) {
                     Log.d(TAG, "Updated a entry from IMovie.TABLE_NAME");
@@ -84,7 +148,22 @@ public class DiskNowPlayingMoviesDataSource implements NowPlayingMoviesDataSourc
                     }
                 }
 
-                //TODO insert in to INowPlayingMovies Table
+                //insert in to INowPlayingMovies Table
+                final MovieID movieID = new MovieID(movie.getId());
+                final String[] whereArgsNowPlaying = {String.valueOf(movieID.getId())};
+                boolean isNowPlayingUpdated = db.update(INowPlayingMovie.TABLE_NAME, movieID.toContentValues(), whereClauseNowPlaying, whereArgsNowPlaying) > 0;
+                if (isNowPlayingUpdated) {
+                    Log.d(TAG, "Updated a entry from INowPlayingMovie.TABLE_NAME");
+                } else {
+                    Log.d(TAG, "Not Updated any entry from INowPlayingMovie.TABLE_NAME");
+                    //NEED INSERT IF RECORDS IS NOT EXIST
+                    boolean isInserted = db.insert(INowPlayingMovie.TABLE_NAME, null, movieID.toContentValues()) > 0;
+                    if (isInserted) {
+                        Log.d(TAG, "Successfully inserted in to INowPlayingMovie.TABLE_NAME.");
+                    } else {
+                        Log.d(TAG, "Not inserted in to INowPlayingMovie.TABLE_NAME.");
+                    }
+                }
             }
             db.setTransactionSuccessful();
         } catch (SQLException e) {


### PR DESCRIPTION
Now Playing Movie offline rendering implemented

## Description
When there is no internet connection, use cache now playing list in the SQLite Table from the previous remote Now Playing Movie Repository response

## Related Issue
Resolved #9 

## Motivation and Context
Now Playing Rendering in the Home Screen Offline Support

## How Has This Been Tested?
1)Connect to the internet and open the app first time to cache Now Playing Movies in to SQLite table.
2) Turn off the internet connection on the device and then open app agin will render the Now Playing Movie list in the home screen from Local Repository

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

